### PR TITLE
Bugfix for reproducing paper results

### DIFF
--- a/randsent.py
+++ b/randsent.py
@@ -57,7 +57,7 @@ def get_results(params, seed):
         'word_emb_file': params.word_emb_file, 'word_emb_dim': params.word_emb_dim,
         'usepytorch': True, 'kfold': params.n_folds, 'feat_dim': senteval_feat_dim,
         'random_word_embeddings': params.random_word_embeddings, 'seed': seed,
-        'batch_size': params.se_batch_size, 'network': network
+        'batch_size': params.se_batch_size, 'network': network, 'zero': params.zero
     }, batcher, prepare)
 
     if params.task_type == "downstream":

--- a/randsent.py
+++ b/randsent.py
@@ -57,7 +57,8 @@ def get_results(params, seed):
         'word_emb_file': params.word_emb_file, 'word_emb_dim': params.word_emb_dim,
         'usepytorch': True, 'kfold': params.n_folds, 'feat_dim': senteval_feat_dim,
         'random_word_embeddings': params.random_word_embeddings, 'seed': seed,
-        'batch_size': params.se_batch_size, 'network': network, 'zero': params.zero
+        'batch_size': params.se_batch_size, 'network': network, 'zero': params.zero,
+        'init': params.init
     }, batcher, prepare)
 
     if params.task_type == "downstream":


### PR DESCRIPTION
The `--zero` parameter (default of 1) was being ignored, which meant that words not found in the embedding were randomly initialized rather than set to zero even when using `--zero 1`. That lead to (significantly) weaker results than are given in the paper. This fix leads to the paper's results.